### PR TITLE
修正 LLVM 类型说明中的笔误

### DIFF
--- a/docs/tutorials/05-intermediate-representation.md
+++ b/docs/tutorials/05-intermediate-representation.md
@@ -125,13 +125,14 @@ enum class ValueType {
 ````c++
 enum TypeID {
     // Primitive types
-    VoidTyID,       //空返回值
-    LabelTyID,      //标签类型
+    VoidTyID,       // 空返回值
+    LabelTyID,      // 标签类型
 
     // Derived types
-    IntegerTyID,    //整数类型
-    FunctionTyID,   //浮点数类型
-    PointerTyID     //指针类型
+    IntegerTyID,    // 整数类型
+    FloatTyID,      // 浮点数类型
+    FunctionTyID,   // 函数类型
+    PointerTyID     // 指针类型
 };
 ````
 


### PR DESCRIPTION
修正了“中间代码数据结构 - 以 LLVM IR 为例”中类型说明的笔误。